### PR TITLE
Changed reference from upstream's CurrencyTextView to our CurrencyTextView

### DIFF
--- a/wallet/res/layout/transaction_row_extended.xml
+++ b/wallet/res/layout/transaction_row_extended.xml
@@ -117,7 +117,7 @@
 			android:layout_marginRight="8dp"
 			android:layout_weight="1" />
 
-		<de.schildbach.wallet.ui.CurrencyTextView
+		<de.langerhans.wallet.ui.CurrencyTextView
 			android:id="@+id/transaction_row_fiat"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"


### PR DESCRIPTION
There was a crash on launch for the 2.00 version of the wallet. This was caused by an InflateException when Android tried generating a View from the transaction_row_extended.xml file because the file had a reference to the class file in the upstream package.

This change fixes the crash by changing the offending line in the XML file to refer to the equivalent class in this project's package instead.